### PR TITLE
Astro typesafe env vars

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 import htmx from "astro-htmx";
-import { defineConfig } from "astro/config";
+import { defineConfig, envField } from "astro/config";
 import mkcert from "vite-plugin-mkcert";
 
 import node from "@astrojs/node";
@@ -36,4 +36,13 @@ export default defineConfig({
     plugins: [mkcert()],
   },
   integrations: [tailwind(), alpinejs(), htmx(), pageInsight()],
+  
+  env: {
+    schema: {
+      OPTIMIZELY_GRAPH_SECRET: envField.string({context: "server", access: "secret", optional: false}),
+      OPTIMIZELY_GRAPH_APP_KEY: envField.string({context: "client", access: "public", optional: false}),
+      OPTIMIZELY_GRAPH_SINGLE_KEY: envField.string({context: "client", access: "public", optional: false}),
+      OPTIMIZELY_GRAPH_GATEWAY: envField.string({context: "client", access: "public", optional: false}),
+    }
+  }
 });

--- a/src/services/graphql/getSdk.ts
+++ b/src/services/graphql/getSdk.ts
@@ -3,12 +3,15 @@ import { print } from "graphql";
 
 import { getSdk as getSdkWithClient, Requester } from "./__generated/sdk";
 
+import {OPTIMIZELY_GRAPH_GATEWAY, OPTIMIZELY_GRAPH_APP_KEY, OPTIMIZELY_GRAPH_SINGLE_KEY} from 'astro:env/client'
+import {OPTIMIZELY_GRAPH_SECRET} from 'astro:env/server'
+
 const requesterDraft: Requester<any> = async (doc: any, vars: any) => {
   const token = btoa(
-    `${import.meta.env.OPTIMIZELY_GRAPH_APP_KEY}:${import.meta.env.OPTIMIZELY_GRAPH_APP_SECRET}`,
+    `${OPTIMIZELY_GRAPH_APP_KEY}:${OPTIMIZELY_GRAPH_SECRET}`,
   );
   const previewClient = new GraphQLClient(
-    `${import.meta.env.OPTIMIZELY_GRAPH_GATEWAY}/content/v2`,
+    `${OPTIMIZELY_GRAPH_GATEWAY}/content/v2`,
     {
       headers: {
         authorization: `Basic ${token}`,
@@ -40,7 +43,7 @@ const requesterDraft: Requester<any> = async (doc: any, vars: any) => {
 
 const requesterPublished: Requester<any> = async (doc: any, vars: any) => {
   const client = new GraphQLClient(
-    `${import.meta.env.OPTIMIZELY_GRAPH_GATEWAY}/content/v2?auth=${import.meta.env.OPTIMIZELY_GRAPH_SINGLE_KEY}`,
+    `${OPTIMIZELY_GRAPH_GATEWAY}/content/v2?auth=${OPTIMIZELY_GRAPH_SINGLE_KEY}`,
   );
 
   try {


### PR DESCRIPTION
Update to use Astro's approach to type safe env variables.

Open to your judgment on whether any other vars should be set as server variables. (Might be something to revisit after updating the GraphQL query to use the preview token instead of other auth mode.)