### PR TITLE
Update path for CMS comm script to your CMS instance

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,6 @@
+# The URL to the CMS, without the path (e.g. https://app-your_instance_id.cms.optimizely.com/)
+OPTIMIZELY_CMS_URL=YOUR_CMS_DOMAIN
+
 # Optimizely Graph Keys
 OPTIMIZELY_GRAPH_SECRET=YOUR-SECRET-HERE
 OPTIMIZELY_GRAPH_APP_KEY=YOUR-KEY-HERE

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -39,6 +39,7 @@ export default defineConfig({
   
   env: {
     schema: {
+      OPTIMIZELY_CMS_URL: envField.string({context: "client", access: "public", optional: true}),
       OPTIMIZELY_GRAPH_SECRET: envField.string({context: "server", access: "secret", optional: false}),
       OPTIMIZELY_GRAPH_APP_KEY: envField.string({context: "client", access: "public", optional: false}),
       OPTIMIZELY_GRAPH_SINGLE_KEY: envField.string({context: "client", access: "public", optional: false}),

--- a/src/pages/preview.astro
+++ b/src/pages/preview.astro
@@ -7,6 +7,12 @@ import { ContentPayload } from '../services/shared/ContentPayload'
 import { Locales } from '../services/graphql/__generated/sdk'
 import qs from 'query-string'
 
+import { OPTIMIZELY_CMS_URL } from 'astro:env/client'
+const cmsScript = 
+  (OPTIMIZELY_CMS_URL && OPTIMIZELY_CMS_URL.startsWith("https://") && OPTIMIZELY_CMS_URL.includes(".cms.optimizely.com")) ? 
+	`${OPTIMIZELY_CMS_URL.replace(/\/$/, "")}/util/javascript/communicationinjector.js` : 
+	`/communicationinjector.js`
+
 const previewPayload = qs.parse(Astro.url.search) as unknown as ContentPayload
 
 const optiResponse = await getOptimizelySdk(previewPayload.ctx).contentById({
@@ -33,7 +39,7 @@ const isPageType = types?.includes('_Page') && isExperienceType === false
   {isPageType &&
     <Pages data={previewPayload} />}
 </>
-<script src="/communicationinjector.js" is:inline></script>
+<script src=`${cmsScript}` is:inline></script>
 <script>
   function contentSaved(event: any) {
     window.location = event.detail.previewUrl


### PR DESCRIPTION
Update to directly use the communication script from the CMS instance ([docs](https://docs.developers.optimizely.com/content-management-system/v1.0.0-CMS-SaaS/docs/enable-live-preview-saas#enable-communication-between-cms-and-your-application))

Note: this PR is implemented to avoid breaking change for anyone missing the new env variable. Long-term, can make that variable required via astro.config.mjs, and remove the local version of the script at _public/communicationinjector.js_.