### PR TITLE
Update i18n/localization handling

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -21,6 +21,22 @@ export default defineConfig({
       },
     ],
   },
+  
+  i18n: {
+    locales: ["en", "es", "fr", "fr-CA", "nl", "sv"],
+    defaultLocale: "en",
+    routing: {
+        prefixDefaultLocale: false,
+        fallbackType: "rewrite"
+    },
+    fallback: {
+      es: "en",
+      fr: "en",
+      "fr-CA": "en",
+      nl: "en",
+      sv: "en",
+    },
+  },
 
   output: "server",
 

--- a/src/components/cms/shared/Header.astro
+++ b/src/components/cms/shared/Header.astro
@@ -1,11 +1,12 @@
 ---
-
+import { getRelativeLocaleUrl } from "astro:i18n";
+const lang = Astro.currentLocale;
 ---
 <header class="bg-gray-50 sticky z-50 top-0">
     <div class="mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8">
         <div class="flex h-24 items-center justify-between">
             <div class="flex-1 md:flex md:items-center md:gap-12">
-                <a class="block text-teal-600" href="/en">
+                <a class="block text-teal-600" href={getRelativeLocaleUrl(lang, '/')}>
                     <span class="sr-only">Home</span>
                     <!--<svg class="h-12" viewBox="0 0 28 24" fill="none" xmlns="http://www.w3.org/2000/svg">-->
                     <!--    <path-->
@@ -21,21 +22,19 @@
                 <nav aria-label="Global" class="hidden md:block">
                     <ul class="flex items-center gap-10 text-lg">
                         <li>
-                            <a class="text-gray-500 transition hover:text-gray-500/75" href="#"> About </a>
-                        </li>
-
-                        <li>
-                            <a class="text-gray-500 transition hover:text-gray-500/75" href="#"> Careers </a>
-                        </li>
-
-                        <li>
-                            <a class="text-gray-500 transition hover:text-gray-500/75" href="#"> History </a>
+                            <a class="text-gray-500 transition hover:text-gray-500/75" href={getRelativeLocaleUrl(lang, '#')}> About </a>
                         </li>
                         <li>
-                            <a class="text-gray-500 transition hover:text-gray-500/75" href="/en/blog"> Blog </a>
+                            <a class="text-gray-500 transition hover:text-gray-500/75" href={getRelativeLocaleUrl(lang, '#')}> Careers </a>
                         </li>
                         <li>
-                            <a class="text-gray-500 transition hover:text-gray-500/75" href="/store"> Store </a>
+                            <a class="text-gray-500 transition hover:text-gray-500/75" href={getRelativeLocaleUrl(lang, '#')}> History </a>
+                        </li>
+                        <li>
+                            <a class="text-gray-500 transition hover:text-gray-500/75" href={getRelativeLocaleUrl(lang, '/blog')}> Blog </a>
+                        </li>
+                        <li>
+                            <a class="text-gray-500 transition hover:text-gray-500/75" href={getRelativeLocaleUrl(lang, '/store')}> Store </a>
                         </li>
                     </ul>
                 </nav>

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -6,6 +6,9 @@ import { Locales } from "../services/graphql/__generated/sdk";
 import { getOptimizelySdk } from "../services/graphql/getSdk";
 import { ContentPayload } from "../services/shared/ContentPayload";
 
+import { getRelativeLocaleUrl } from "astro:i18n";
+const lang = Astro.currentLocale;
+
 const ctx = "view";
 
 var contentPayload: ContentPayload = {
@@ -22,7 +25,8 @@ const contentByPathResponse = await getOptimizelySdk(contentPayload).contentByPa
   url: urlPath,
 });
 if (contentByPathResponse._Content.items.length === 0) {
-  return Astro.redirect("/en");
+  // return Astro.redirect("/en");
+  return Astro.redirect(getRelativeLocaleUrl(lang, '/'));
 }
 const item = contentByPathResponse._Content.items[0];
 const contentByIdResponse = await getOptimizelySdk(contentPayload).contentById({

--- a/src/services/graphql/__generated/graphql.schema.graphql
+++ b/src/services/graphql/__generated/graphql.schema.graphql
@@ -2135,6 +2135,11 @@ enum Locales {
   ALL
   NEUTRAL
   en
+  es
+  fr
+  fr_CA
+  nl
+  sv
 }
 
 type MediaMetadata implements IContentMetadata & IInstanceMetadata & IMediaMetadata {

--- a/src/services/graphql/__generated/graphql.schema.json
+++ b/src/services/graphql/__generated/graphql.schema.json
@@ -1,7 +1,8 @@
 {
   "__schema": {
     "queryType": {
-      "name": "Query"
+      "name": "Query",
+      "kind": "OBJECT"
     },
     "mutationType": null,
     "subscriptionType": null,
@@ -25123,6 +25124,36 @@
           },
           {
             "name": "en",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "es",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fr",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fr_CA",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nl",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sv",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null


### PR DESCRIPTION
See below for details.
Note: issue reported about editing non-English content and auto-generated preview URL.

Required setup:
- Set "en" to be default language (URLs will not include "en" language prefix):
	- CMS > Settings > Applications > Application Hostname: set Locale == "en"

Languages:
- Available in frontend code by default (with fallbacks to _en_): 
	- en (default)
	- es
	- fr
	- fr-CA
	- nl
	- sv

- To fully enable those languages in your instance:
	- CMS > Settings > Languages > enable language

- To add/enable additional languages:
	- CMS > Settings > Languages > enable language
	- Create + publish content (can be just a test page) in that new language
	- Regenerate the graphql code for the frontend:
		_yarn codegen_
	- Update frontend code: astro.config.mjs
		- Add new locale(s), and new fallback setup
