### PR TITLE
Handle original URL when simple address is defined on page

### DIFF
--- a/src/graphql/queries/contentByPath.graphql
+++ b/src/graphql/queries/contentByPath.graphql
@@ -2,7 +2,14 @@ query contentByPath($base: String, $url: String!) {
     _Content(
         where: {
             _metadata: { url: { base: { eq: $base } } }
-            _and: { _metadata: { url: { default: { eq: $url } } } }
+            _and: [
+                {
+                    _or: [
+                        { _metadata: { url: { default: { eq: $url } } } }
+                        { _metadata: { url: { hierarchical: { eq: $url } } } }
+                    ]
+                }
+            ]
         }
     ) {
         item {


### PR DESCRIPTION
Note: this change enables the original (full) URL to work when a Simple Address is set on a page.

The Simple Address does not route correctly, due to how the URL is stored in Graph (no trailing slash); waiting feedback from Support team.