### PR TITLE
Update text component heading style rendering

### DIFF
--- a/src/cms/components/TextComponent/Text.astro
+++ b/src/cms/components/TextComponent/Text.astro
@@ -1,9 +1,11 @@
 ---
+import { json } from 'stream/consumers';
 import type {
     DisplaySettingsFragment,
     TextFragment,
 } from '../../../../__generated/sdk';
 import type { ContentPayload } from '../../../graphql/shared/ContentPayload';
+import { getDictionaryFromDisplaySettings } from '../../../graphql/shared/displaySettingsHelpers.ts';
 import { getHeadingElementStyles } from './TextStyling';
 
 export interface Props {
@@ -12,8 +14,14 @@ export interface Props {
     displaySettings: DisplaySettingsFragment[];
 }
 const { data, displaySettings } = Astro.props as Props;
+
+const settings: Record<string, string> =
+    getDictionaryFromDisplaySettings(displaySettings);
+const HeadingStyle = (settings?.headingType == "plain" || settings?.headingType == null) 
+    ? "span" : settings.headingType;
+
 ---
 
-<div class:list={getHeadingElementStyles(displaySettings)}>
+<HeadingStyle class:list={getHeadingElementStyles(displaySettings)}>
     {data.Content}
-</div>
+</HeadingStyle>

--- a/src/cms/components/TextComponent/Text.astro
+++ b/src/cms/components/TextComponent/Text.astro
@@ -1,5 +1,4 @@
 ---
-import { json } from 'stream/consumers';
 import type {
     DisplaySettingsFragment,
     TextFragment,

--- a/src/cms/components/TextComponent/TextStyling.ts
+++ b/src/cms/components/TextComponent/TextStyling.ts
@@ -34,43 +34,5 @@ export function getHeadingElementStyles(
             cssClasses.push('capitalize');
             break;
     }
-    switch (settings['headingType']) {
-        case 'h1':
-            cssClasses.push('font-bold my-0');
-            cssClasses.push('text-[4.8rem]');
-            cssClasses.push('lg:text-[6.4rem]');
-            cssClasses.push('xl:text-[7.2rem]');
-            break;
-        case 'h2':
-            cssClasses.push('font-bold my-0');
-            cssClasses.push('text-[4.2rem]');
-            cssClasses.push('lg:text-[4.8rem]');
-            cssClasses.push('xl:text-[6.4rem]');
-            break;
-        case 'h3':
-            cssClasses.push('font-bold my-0');
-            cssClasses.push('text-[3.6rem]');
-            cssClasses.push('lg:text-[4.2rem]');
-            cssClasses.push('xl:text-[4.8rem]');
-            break;
-        case 'h4':
-            cssClasses.push('font-bold my-0');
-            cssClasses.push('text-[3.6rem]');
-            cssClasses.push('lg:text-[3.8rem]');
-            cssClasses.push('xl:text-[4.2rem]');
-            break;
-        case 'h5':
-            cssClasses.push('font-bold my-0');
-            cssClasses.push('text-[3.6rem]');
-            cssClasses.push('lg:text-[3.0rem]');
-            cssClasses.push('xl:text-[3.2rem]');
-            break;
-        case 'h6':
-            cssClasses.push('font-bold my-0');
-            break;
-        case 'plain':
-            cssClasses.push('my-0');
-            break;
-    }
     return cssClasses;
 }


### PR DESCRIPTION
Updated Text Component to use standard \<h1>, \<h2>, etc styles, for consistency with other text/paragraph/tinymce content

Base site styles for header tags can be updated in: [tailwind.config.mjs](/opti-astro/blob/main/tailwind.config.mjs)

For reference, original styles applied by the Text component:

<pre>        case 'h1':
            cssClasses.push('font-bold my-0');
            cssClasses.push('text-[4.8rem]');
            cssClasses.push('lg:text-[6.4rem]');
            cssClasses.push('xl:text-[7.2rem]');
            break;
        case 'h2':
            cssClasses.push('font-bold my-0');
            cssClasses.push('text-[4.2rem]');
            cssClasses.push('lg:text-[4.8rem]');
            cssClasses.push('xl:text-[6.4rem]');
            break;
        case 'h3':
            cssClasses.push('font-bold my-0');
            cssClasses.push('text-[3.6rem]');
            cssClasses.push('lg:text-[4.2rem]');
            cssClasses.push('xl:text-[4.8rem]');
            break;
        case 'h4':
            cssClasses.push('font-bold my-0');
            cssClasses.push('text-[3.6rem]');
            cssClasses.push('lg:text-[3.8rem]');
            cssClasses.push('xl:text-[4.2rem]');
            break;
        case 'h5':
            cssClasses.push('font-bold my-0');
            cssClasses.push('text-[3.6rem]');
            cssClasses.push('lg:text-[3.0rem]');
            cssClasses.push('xl:text-[3.2rem]');
            break;
        case 'h6':
            cssClasses.push('font-bold my-0');
            break;
        case 'plain':
            cssClasses.push('my-0');
            break;`
</pre>