### PR TITLE
Pull content types from CMS

### DIFF
--- a/utils/types/pull.mjs
+++ b/utils/types/pull.mjs
@@ -1,4 +1,5 @@
 import { createClient } from '@remkoj/optimizely-cms-api';
+import fg from 'fast-glob';
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -6,10 +7,18 @@ import { fileURLToPath } from 'url';
 // Convert import.meta.url to a usable file path
 const currentFilename = fileURLToPath(import.meta.url);
 const currentDirectory = path.dirname(currentFilename);
-const directoryToFindStylesIn = path.resolve(
-    `${currentDirectory}/../../src/cms`
-); // looking for pattern *.opti-style.json
-const directoryToPullStylesInto = path.resolve(`${currentDirectory}/temp`); // temp directory to store pulled styles
+
+// use temp directory in .gitignore to store pulled types while WIP
+const directoryToPullTypesInto = fg.convertPathToPattern(path.resolve(`${currentDirectory}/temp`)); 
+// const directoryToPullTypesInto = fg.convertPathToPattern(path.resolve(`${currentDirectory}/content_types`));
+
+if(!(await folderExists(directoryToPullTypesInto))) {
+    console.log("Creating output folder.")
+    if(await createDirectory(directoryToPullTypesInto)) {
+        console.log(`✅ Output folder "${directoryToPullTypesInto}" created.`);
+    } 
+}
+
 const clientId = process.env.OPTIMIZELY_CLIENT_ID;
 const clientSecret = process.env.OPTIMIZELY_CLIENT_SECRET;
 const cmsUrl = process.env.OPTIMIZELY_CMS_URL;
@@ -23,24 +32,30 @@ const config = {
 const client = createClient(config);
 
 const contentTypesList = await client.contentTypes.contentTypesList();
-contentTypesList.items?.forEach(async (contentType) => {
-    //console.log(contentType);
-    const realContentType = await client.contentTypes.contentTypesGet(
-        contentType.key
-    );
-    if (
-        realContentType.baseType === 'component' ||
-        realContentType.baseType === 'page'
-    )
-        return;
-    console.log(realContentType);
-    // fs.writeFile(
-    //     `${directoryToPullStylesInto}/${styleKey}.opti-style.json`,
-    //     JSON.stringify(styleDefinition, null, 2)
+const contentTypesListSorted = contentTypesList.items.sort((a, b) => a.key.localeCompare(b.key));
+
+contentTypesListSorted?.forEach(async (contentType) => {
+    // const contentTypeKey = contentType.key;
+    // const realContentType = await client.contentTypes.contentTypesGet(
+    //     contentType.key
     // );
-    // console.log(
-    //     `Template with styleKey: ${styleKey} and contentType: ${styleDefinition.contentType} has been pulled`
-    // );
+    // console.log(contentTypeKey)
+    if (contentType !== undefined && 
+        contentType !== '' && 
+        contentType.source != "system" &&
+        (await folderExists(directoryToPullTypesInto))) {
+
+        const contentTypeKey = capitalize(contentType.key);
+        fs.writeFile(
+            `${directoryToPullTypesInto}/${contentTypeKey}.opti-type.json`,
+            JSON.stringify(contentType, null, 2)
+        );
+        console.log(
+            `✅ Content type for type "${contentTypeKey}" has been pulled, and template was created`
+        );
+    }
+
+    return;
 });
 
 async function folderExists(path) {
@@ -49,7 +64,17 @@ async function folderExists(path) {
         //console.log(`✅ Folder "${path}" exists.`);
         return true;
     } catch (error) {
-        //console.log(`❌ Folder "${path}" does not exist.`);
+        console.log(`❌ Output folder "${path}" does not exist.`);
+        return false;
+    }
+}
+
+async function createDirectory(path) {
+    try {
+        await fs.mkdir(path);
+        return true;
+    } catch(error) {
+        console.log(`❌ Error creating output folder "${path}".`);
         return false;
     }
 }


### PR DESCRIPTION
Note: currently stores content types in a temp directory in .gitignore, to avoid tracking current versions of content types. To be updated when ready, so content types are included in repo.