### PR TITLE
Fix SimpleAddress, add canonical URL when used

### DIFF
--- a/src/cms/experiences/_Experiences.astro
+++ b/src/cms/experiences/_Experiences.astro
@@ -24,12 +24,15 @@ if (experience?._metadata?.types?.includes('BlankExperience')) {
     metaDescription =
         blankExperience.BlankExperienceSeoSettings?.MetaDescription || '';
 }
+
+const hierarchicalUrl = experience?._metadata?.url?.type === "SIMPLE" ? experience?._metadata?.url?.hierarchical : '';
 ---
 
 <Layout
     title={metaTitle}
     description={metaDescription}
     contentPayload={previewPayload}
+    hierarchicalUrl={hierarchicalUrl ?? ''}
 >
     <div class="vb:outline relative w-full flex-1">
         {

--- a/src/cms/pages/ArticlePage/ArticlePage.astro
+++ b/src/cms/pages/ArticlePage/ArticlePage.astro
@@ -22,12 +22,15 @@ const publishedDate = format(
     new Date(post?._metadata?.published ?? Date.now()),
     'dd MMM yyyy'
 );
+
+const hierarchicalUrl = post?._metadata?.url?.type === "SIMPLE" ? post?._metadata?.url?.hierarchical : '';
 ---
 
 <Layout
     title={post.SeoSettings?.MetaTitle ?? ''}
     description={post.SeoSettings?.MetaDescription ?? ''}
     contentPayload={contentPayload}
+    hierarchicalUrl={hierarchicalUrl ?? ''}
 >
     <div class="max-w-screen-6xl mx-auto">
         <main class="mt-10">

--- a/src/cms/pages/ArticlePage/articlePage.graphql
+++ b/src/cms/pages/ArticlePage/articlePage.graphql
@@ -2,6 +2,8 @@ fragment ArticlePage on ArticlePage {
     _metadata {
         url {
             default
+            hierarchical
+            type
         }
         published
     }

--- a/src/cms/pages/LandingPage/LandingPage.astro
+++ b/src/cms/pages/LandingPage/LandingPage.astro
@@ -19,12 +19,15 @@ const optiResponse = await getOptimizelySdk(contentPayload).pageById({
 });
 
 const page = optiResponse?._Page?.item as LandingPageFragment;
+
+const hierarchicalUrl = page?._metadata?.url?.type === "SIMPLE" ? page?._metadata?.url?.hierarchical : '';
 ---
 
 <Layout
     title={page.SeoSettings?.MetaTitle ?? ''}
     description={page.SeoSettings?.MetaDescription ?? ''}
     contentPayload={contentPayload}
+    hierarchicalUrl={hierarchicalUrl ?? ''}
 >
     <!--Top content area-->
     {

--- a/src/cms/pages/LandingPage/landingPage.graphql
+++ b/src/cms/pages/LandingPage/landingPage.graphql
@@ -1,4 +1,12 @@
 fragment LandingPage on LandingPage {
+    _metadata {
+        url {
+            default
+            hierarchical
+            type
+        }
+        published
+    }
     TopContentArea {
         _metadata {
             types

--- a/src/graphql/queries/contentByPath.graphql
+++ b/src/graphql/queries/contentByPath.graphql
@@ -1,4 +1,4 @@
-query contentByPath($base: String, $url: String!) {
+query contentByPath($base: String, $url: String!, $urlNoSlash: String!) {
     _Content(
         where: {
             _metadata: { url: { base: { eq: $base } } }
@@ -6,6 +6,7 @@ query contentByPath($base: String, $url: String!) {
                 {
                     _or: [
                         { _metadata: { url: { default: { eq: $url } } } }
+                        { _metadata: { url: { default: { eq: $urlNoSlash } } } }
                         { _metadata: { url: { hierarchical: { eq: $url } } } }
                     ]
                 }

--- a/src/graphql/queries/experience.graphql
+++ b/src/graphql/queries/experience.graphql
@@ -12,6 +12,8 @@ query getExperience($key: String, $ver: String, $loc: [Locales]) {
                 version
                 url {
                     default
+                    hierarchical
+                    type
                 }
                 types
             }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,9 +9,10 @@ interface Props {
     title: string;
     description: string;
     contentPayload: ContentPayload;
+    hierarchicalUrl?: string;
 }
 
-const { title, description, contentPayload } = Astro.props;
+const { title, description, contentPayload, hierarchicalUrl } = Astro.props;
 const { host } = Astro.url;
 const siteSettings = await getOptimizelySdk(
     contentPayload
@@ -19,6 +20,8 @@ const siteSettings = await getOptimizelySdk(
     domain: host,
     locale: [contentPayload.loc as Locales],
 });
+
+const canonicalUrl = Astro.url.origin + hierarchicalUrl;
 ---
 
 <!doctype html>
@@ -29,6 +32,9 @@ const siteSettings = await getOptimizelySdk(
         <meta name="viewport" content="width=device-width" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <meta name="generator" content={Astro.generator} />
+        {hierarchicalUrl && 
+            <link rel="canonical" href={canonicalUrl} />
+        }
         <title>{title}</title>
     </head>
     <body>

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -21,12 +21,14 @@ var contentPayload: ContentPayload = {
 };
 
 const urlPath = `${Astro.url.pathname.replace(/\/$/, '')}/`;
+const urlPathNoSlash = `${Astro.url.pathname.replace(/\/$/, '')}`;
 const urlBase = Astro.url.origin;
 const contentByPathResponse = await getOptimizelySdk(
     contentPayload
 ).contentByPath({
     base: urlBase,
     url: urlPath,
+    urlNoSlash: urlPathNoSlash
 });
 if (!contentByPathResponse._Content 
     || !contentByPathResponse._Content.item 


### PR DESCRIPTION
Handle Simple Address, with no trailing slash as stored in Graph

Add canonical URL to head of pages with Simple Address defined