### PR TITLE
Add iframe component type

### DIFF
--- a/src/cms/components/IframeComponent/Iframe.astro
+++ b/src/cms/components/IframeComponent/Iframe.astro
@@ -1,0 +1,37 @@
+---
+import type {
+    DisplaySettingsFragment,
+    IframeFragment,
+} from '../../../../__generated/sdk.ts';
+import type { ContentPayload } from '../../../graphql/shared/ContentPayload.ts';
+import { getDictionaryFromDisplaySettings } from '../../../graphql/shared/displaySettingsHelpers.ts';
+// import { getHeadingElementStyles } from './IframeStyling.ts';
+
+export interface Props {
+    data: IframeFragment;
+    contentPayload: ContentPayload;
+    displayTemplateKey: string;
+    displaySettings: DisplaySettingsFragment[];
+}
+const { data, displaySettings } = Astro.props as Props;
+
+const settings: Record<string, string> =
+    getDictionaryFromDisplaySettings(displaySettings);
+
+ const allWidths : { [key: string]: any } = 
+    {'w-full': '',
+    'w-1/4': 'md:w-1/4',
+    'w-1/3': 'md:w-1/3',
+    'w-1/2': 'md:w-1/2',
+    'w-2/3': 'md:w-2/3',
+    'w-3/4': 'md:w-3/4',
+    };
+
+const width = allWidths[settings?.Width] || '';
+
+---
+
+<div class={`mb-3`}>
+    <iframe class=`w-full ${width}` height={data?.ManualHeight} src={data?.IframePageUrl} title={data?.Title} style="border:0;" allow="" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+

--- a/src/cms/components/IframeComponent/iframe.graphql
+++ b/src/cms/components/IframeComponent/iframe.graphql
@@ -1,0 +1,6 @@
+fragment Iframe on Iframe {
+    Title
+    IframePageUrl
+    ManualHeight
+    Width
+}

--- a/src/cms/components/_Components.astro
+++ b/src/cms/components/_Components.astro
@@ -7,6 +7,7 @@ import Carousel from './CarouselComponent/Carousel.astro';
 import Collapse from './CollapseComponent/Collapse.astro';
 import Grid from './GridComponent/Grid.astro';
 import Hero from './HeroComponent/Hero.astro';
+import Iframe from './IframeComponent/Iframe.astro';
 import Image from './ImageComponent/Image.astro';
 import Paragraph from './ParagraphComponent/Paragraph.astro';
 import Text from './TextComponent/Text.astro';
@@ -115,6 +116,16 @@ const componentType = component._metadata.types[0];
 {
     componentType === 'Grid' && (
         <Grid
+            contentPayload={contentPayload}
+            data={component}
+            displaySettings={displaySettings}
+            displayTemplateKey={displayTemplateKey}
+        />
+    )
+}
+{
+    componentType === 'Iframe' && (
+        <Iframe
             contentPayload={contentPayload}
             data={component}
             displaySettings={displaySettings}

--- a/src/cms/components/allComponents.graphql
+++ b/src/cms/components/allComponents.graphql
@@ -14,4 +14,5 @@ fragment AllComponentsExceptGrid on _IComponent {
     ...Carousel
     ...Collapse
     ...ArticleList
+    ...Iframe
 }


### PR DESCRIPTION


New iframe component content type for iframe component -- to add to existing site, remove ".zip" from the end of the file name to import:
[iframe_component.ExportedFile.episerverdata.zip](https://github.com/user-attachments/files/20432670/iframe_component.ExportedFile.episerverdata.zip)
