### PR TITLE
Ignore content types created via DAM integration

### DIFF
--- a/utils/types/pull.mjs
+++ b/utils/types/pull.mjs
@@ -28,7 +28,8 @@ contentTypesListSorted?.forEach(async (contentType) => {
     if (
         contentType !== undefined &&
         contentType !== '' &&
-        contentType.source != 'system'
+        contentType.source != 'system' &&
+        contentType.source != 'graph'
     ) {
         // Clean up the content type object by removing unwanted properties
         const cleanContentType = { ...contentType };


### PR DESCRIPTION
With DAM enabled on the CMS instance, the pull script tries to pull 3 new types:
graph:cmp_PublicImageAsset
graph:cmp_PublicRawFileAsset
graph:cmp_PublicVideoAsset

I don't think there's any need to include those in the project, correct?