### PR TITLE
Add FolderPage type for organizing page tree

### DIFF
--- a/src/cms/pages/FolderPage/FolderPage.astro
+++ b/src/cms/pages/FolderPage/FolderPage.astro
@@ -1,0 +1,21 @@
+---
+
+---
+
+<div style="
+    margin: 68px auto;
+    padding: 64px 24px;
+    background: #f8f9fa;
+    border-radius: 12px;
+    box-shadow: 0 2px 12px rgba(0,0,0,0.07);
+    text-align: center;
+    height: 100%;
+">
+    <h1 style="font-size: 2rem; margin-bottom: 16px; color: #333;">
+        No preview for Folder Page
+    </h1>
+    <p style="font-size: 1.2rem; color: #555; line-height: 1.5rem;">
+        This page type is used for organizing content in the page tree.<br>
+        Folder pages do not have a specific layout or content to display.
+    </p>
+</div>

--- a/src/cms/pages/FolderPage/FolderPage.opti-type.json
+++ b/src/cms/pages/FolderPage/FolderPage.opti-type.json
@@ -1,0 +1,25 @@
+{
+	"key": "FolderPage",
+	"displayName": "Folder",
+	"description": "Folder type for organizing items in page tree",
+	"baseType": "page",
+	"sortOrder": 0,
+	"mayContainTypes": [
+		"*"
+	],
+	"mediaFileExtensions": [],
+	"compositionBehaviors": [],
+	"properties": {
+		"FolderDescription": {
+			"type": "string",
+			"format": "shortString",
+			"displayName": "Folder Description",
+			"description": "",
+			"localized": false,
+			"required": false,
+			"group": "Information",
+			"sortOrder": 7,
+			"editorSettings": {}
+		}
+	}
+}

--- a/src/cms/pages/_Pages.astro
+++ b/src/cms/pages/_Pages.astro
@@ -3,6 +3,7 @@ import type { ContentPayload } from '../../graphql/shared/ContentPayload';
 import ArticlePage from './ArticlePage/ArticlePage.astro';
 import LandingPage from './LandingPage/LandingPage.astro';
 import MockupPage from './MockupPage/MockupPage.astro';
+import FolderPage from './FolderPage/FolderPage.astro';
 const contentPayload = Astro.props.data as ContentPayload;
 const pageType = contentPayload.types[0];
 ---
@@ -10,3 +11,4 @@ const pageType = contentPayload.types[0];
 {pageType === 'ArticlePage' && <ArticlePage contentPayload={contentPayload} />}
 {pageType === 'LandingPage' && <LandingPage contentPayload={contentPayload} />}
 {pageType === 'MockupPage' && <MockupPage contentPayload={contentPayload} />}
+{pageType === 'FolderPage' && <FolderPage />}

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -125,6 +125,10 @@ const isComponentType = contentPayload.types.includes('_Component');
 const isExperienceType = contentPayload.types.includes('_Experience');
 const isPageType =
     contentPayload.types.includes('_Page') && isExperienceType === false;
+
+if(isPageType && contentPayload.types.includes('FolderPage')) {
+    return Astro.redirect(getRelativeLocaleUrl(lang, '/404'), 404);
+}
 ---
 
 <>

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -126,7 +126,7 @@ const isExperienceType = contentPayload.types.includes('_Experience');
 const isPageType =
     contentPayload.types.includes('_Page') && isExperienceType === false;
 
-if(isPageType && contentPayload.types.includes('FolderPage')) {
+if (isPageType && contentPayload.types.includes('FolderPage')) {
     return Astro.redirect(getRelativeLocaleUrl(lang, '/404'), 404);
 }
 ---


### PR DESCRIPTION
Simple page type to help with organizing page tree.

Renders simple "no preview" message inside CMS; returns 404 outside of CMS.