### PR TITLE
Additional options for ArticleList Component

### DIFF
--- a/src/cms/components/ArticleListComponent/ArticleList.astro
+++ b/src/cms/components/ArticleListComponent/ArticleList.astro
@@ -21,12 +21,13 @@ export interface Props {
     contentPayload: ContentPayload;
 }
 const { key, data, displaySettings, contentPayload } = Astro.props as Props;
-const currentSite = Astro.url.origin;
+const currentSite = data.IncludeAllSites ? null : Astro.url.origin;
 const articlesList = await getOptimizelySdk(contentPayload).getArticles({
     //@ts-ignore
     loc: contentPayload.loc,
     site: currentSite,
     limit: data.NumberOfArticles || 1,
+    rootUrl: data.ArticleRoot?.url?.default || '/',
 });
 const glideId = randomBytes(5).toString('hex');
 const items = articlesList.ArticlePage?.items || null;

--- a/src/cms/components/ArticleListComponent/ArticleList.opti-type.json
+++ b/src/cms/components/ArticleListComponent/ArticleList.opti-type.json
@@ -32,6 +32,30 @@
 			"sortOrder": 100,
 			"editorSettings": {},
 			"minimum": 1
+		},
+		"ArticleRoot": {
+			"type": "contentReference",
+			"displayName": "Article Root",
+			"description": "Section of the site to pull listed articles from",
+			"localized": false,
+			"required": false,
+			"group": "Information",
+			"sortOrder": 200,
+			"editorSettings": {},
+			"allowedTypes": [
+				"Page"
+			],
+			"restrictedTypes": []
+		},
+		"IncludeAllSites": {
+			"type": "boolean",
+			"displayName": "Include Articles from all sites",
+			"description": "Include Articles from all sites",
+			"localized": false,
+			"required": false,
+			"group": "Information",
+			"sortOrder": 400,
+			"editorSettings": {}
 		}
 	}
 }

--- a/src/cms/components/ArticleListComponent/articleList.graphql
+++ b/src/cms/components/ArticleListComponent/articleList.graphql
@@ -1,4 +1,10 @@
 fragment ArticleList on ArticleList {
     Title
     NumberOfArticles
+    ArticleRoot {
+        url {
+            default
+        }
+    }
+    IncludeAllSites
 }

--- a/src/graphql/queries/pages/getArticles.graphql
+++ b/src/graphql/queries/pages/getArticles.graphql
@@ -3,15 +3,17 @@ query getArticles(
     $limit: Int! = 15
     $site: String
     $status: String! = "Published"
+    $rootUrl: String
 ) {
     ArticlePage(
         locale: $loc
         orderBy: { _metadata: { published: DESC } }
         limit: $limit
         where: {
-            _metadata: { 
-                status: { eq: $status }, 
-                url: { base: { eq: $site } } }
+            _metadata: {
+                status: { eq: $status }
+                url: { base: { eq: $site }, default: { startsWith: $rootUrl } }
+            }
         }
     ) {
         items {


### PR DESCRIPTION
updates to the ArticleList Component, adding two properties:

- ⁠Article Root -- Section of the site to pull listed articles from (so, for example, you select a page and the list block will only show Articles from underneath that page in the tree)
- Include Articles from all sites -- if you have multiple sites in your instance, checking this will make the list block include articles from all sites (instead of just the default current site)