### PR TITLE
Fix/opti web cms variations

### DIFF
--- a/docs/OPTIMIZELY-WEB-INTEGRATION.md
+++ b/docs/OPTIMIZELY-WEB-INTEGRATION.md
@@ -8,24 +8,24 @@ Note: ensure your Optimizely Web project snippet is added to your site, via the 
 
 ```
 {
-"plugin_type": "widget",
-"name": "SaaS CMS Variations DI",
-"edit_page_url": "https://variations-di.netlify.app/variations",
-"form_schema": [
-{
-"name": "variationName",
-"label": "Variation Name",
-"default_value": "",
-"field_type": "text",
-"options": null
-}
-],
-"description": "",
-"options": {
-"html": "",
-"css": "",
-"apply_js": "(function() {\n    const customString = extension.variationName;\n    const cookieName = 'cmsvariation';\n    const path = window.location.pathname;\n    const domain = window.location.hostname;\n\n    function getCookie(name) {\n        const value = `; ${document.cookie}`;\n        const parts = value.split(`; ${name}=`);\n        if (parts.length === 2) {\n            return parts.pop().split(';').shift();\n        }\n        return null;\n    }\n\n    const variationFromCookie = getCookie(cookieName);\n\n    if (!variationFromCookie) {\n        const expires = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toUTCString();\n        document.cookie = `${cookieName}=${customString}; path=${path}; expires=${expires}; domain=${domain}; SameSite=Lax`;\n        \n        window.location.reload();\n    } else {\n        console.log(`User is in variation: ${variationFromCookie}`);\n        \n    }\n})();",
-"undo_js": "(function() {\n    const cookieName = 'cmsvariation';\n    const path = window.location.pathname;\n    const domain = window.location.hostname;\n    document.cookie = `${cookieName}=; path=${path}; expires=Thu, 01 Jan 1970 00:00:00 UTC; domain=${domain}; SameSite=Lax`;\n})();"
-}
+    "plugin_type": "widget",
+    "name": "SaaS CMS Variations DI",
+    "edit_page_url": "https://variations-di.netlify.app/variations",
+    "form_schema": [
+        {
+            "name": "variationName",
+            "label": "Variation Name",
+            "default_value": "",
+            "field_type": "text",
+            "options": null
+        }
+    ],
+    "description": "",
+    "options": {
+        "html": "",
+        "css": "",
+        "apply_js": "(function() {\n    const customString = extension.variationName;\n    \n    let pathSegment = window.location.pathname;\n    if (pathSegment === '/') {\n        pathSegment = 'homepage';\n    } else {\n        pathSegment = pathSegment.replace(/^\\//, '').replace(/[\\/|-]/g, '_');\n    }\n    \n    const cookieName = `cmsvariation_${pathSegment}`;\n    \n    let path = window.location.pathname;\n    if (path.length > 1 && path.endsWith('/')) {\n        path = path.slice(0, -1);\n    }\n    const domain = window.location.hostname;\n\n    function getCookie(name) {\n        const value = `; ${document.cookie}`;\n        const parts = value.split(`; ${name}=`);\n        if (parts.length === 2) {\n            return parts.pop().split(';').shift();\n        }\n        return null;\n    }\n\n    const variationFromCookie = getCookie(cookieName);\n\n    if (!variationFromCookie) {\n        const expires = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toUTCString();\n        document.cookie = `${cookieName}=${customString}; path=${path}; expires=${expires}; domain=${domain}; SameSite=Lax`;\n        \n        window.location.reload();\n    } else {\n        console.log(`User is in variation: ${variationFromCookie}`);\n        \n    }\n})();",
+        "undo_js": "(function() {\n    let pathSegment = window.location.pathname;\n    if (pathSegment === '/') {\n        pathSegment = 'homepage';\n    } else {\n        pathSegment = pathSegment.replace(/^\\//, '').replace(/[\\/|-]/g, '_');\n    }\n    \n    const cookieName = `cmsvariation_${pathSegment}`;\n    \n    let path = window.location.pathname;\n    if (path.length > 1 && path.endsWith('/')) {\n        path = path.slice(0, -1);\n    }\n    const domain = window.location.hostname;\n    document.cookie = `${cookieName}=; path=${path}; expires=Thu, 01 Jan 1970 00:00:00 UTC; domain=${domain}; SameSite=Lax`;\n})();"
+    }
 }
 ```

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -18,7 +18,7 @@ Astro.response.headers.set('Content-Type', 'text/html; charset=UTF-8');
 
 const lang = getCurrentLocale(Astro);
 
-// Opti Web variation cookie handling
+// Opti Web variation cookie handling -- cookie name depends on page path
 const rawPath = Astro.url.pathname; 
 let pathSegment;
 if (rawPath === '/') {
@@ -27,9 +27,7 @@ if (rawPath === '/') {
     pathSegment = rawPath.replace(/^\//, '').replace(/[\/|-]/g, '_');
 }
 const cookieName = `cmsvariation_${pathSegment}`;
-// Retrieve the cookie using the unique, page-specific name
-const pageVariationWeb = Astro.cookies.get(cookieName)?.value || null; 
-// const pageVariationWeb = Astro.cookies.get('cmsvariation')?.value || null;
+const pageVariationWeb = Astro.cookies.get(cookieName)?.value || null;
 
 // Initialize debug session
 const debugInfo = initFXDebugSession(Astro.url.toString(), lang);


### PR DESCRIPTION
Update Opti Web + CMS integration to use a dynamic cookie name based on page path

Avoids issue of cmsvariation cookie being applied to sub-pages (which led to 404s)