### PR TITLE
Add xml sitemap to robots.txt based on current domain

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,0 @@
-User-agent: *
-User-agent: AdsBot-Google
-Disallow: /

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from 'astro';
+
+const getRobotsTxt = (sitemapURL: URL) => `\
+User-agent: *
+User-agent: AdsBot-Google
+User-agent: Googlebot-Image
+Disallow: /
+
+Sitemap: ${sitemapURL.href}
+`;
+
+export const GET: APIRoute = ({ request }) => {
+    const site = import.meta.env.SITEMAP_BASE_URL || new URL(request.url).origin;
+    const sitemapURL = new URL('sitemap-index.xml', site);
+    return new Response(getRobotsTxt(sitemapURL));
+};


### PR DESCRIPTION
Dynamically adds sitedomain.com/sitemap.xml to the robots.txt file, based on:
1) env var _SITEMAP_BASE_URL_ -- NOTE: additional details about this env var will be added via https://github.com/kunalshetye/opti-astro/pull/231
2) current domain/origin

Note: does not add other language XML sitemap links.